### PR TITLE
Added an argument to Teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/settings.json
+*.pyc

--- a/api/v1/app.py
+++ b/api/v1/app.py
@@ -30,7 +30,7 @@ def not_found(error):
 
 # Teardown 
 @app.teardown_appcontext
-def teardown_db():
+def teardown_db(exception=None):
     storage.close()
 
 


### PR DESCRIPTION
Ran the application locally and found that it was throwing a type error when preforming db_taredown because it had no arguments. So I added the ability for it to take exceptions, and this corrected the initial test.