### PR TITLE
Accidently overrode the object..

### DIFF
--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -56,10 +56,10 @@ def update_state(state_id):
     state = storage.get(State, state_id)
     if not state:
         abort(404)
-    request = request.get_json()
-    if not request:
+    json_data = request.get_json()
+    if not json_data:
         abort(400, description="Not a JSON")
-    for key, value in request.items():
+    for key, value in json_data.items():
         if key not in ['id','created_at', 'updated_at']:
             setattr(state, key, value)
     state.save()


### PR DESCRIPTION
So, I used request as a variable to save the the items when running request.get_json(), so when trying to run requests.items(), I believe it was referencing the last object used (request.get_json()) and not the object created by accessing the data, causing an error. Renaming the variable should correct this.